### PR TITLE
Remove the limitations on the overshoot effect

### DIFF
--- a/example/lib/src/complex_example/complex_example.dart
+++ b/example/lib/src/complex_example/complex_example.dart
@@ -9,7 +9,6 @@ class ComplexExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const Scaffold(
-      extendBody: true,
       bottomNavigationBar: ExampleBottomAppBar(),
       body: NestedNavigator(child: AlbumList()),
     );

--- a/example/lib/src/modal_dialog_example.dart
+++ b/example/lib/src/modal_dialog_example.dart
@@ -2,37 +2,99 @@ import 'package:example/src/common.dart';
 import 'package:exprollable_page_view/exprollable_page_view.dart';
 import 'package:flutter/material.dart';
 
-class ModalDialogExample extends StatelessWidget {
+class ModalDialogExample extends StatefulWidget {
   const ModalDialogExample({super.key});
+
+  @override
+  State<ModalDialogExample> createState() => _ModalDialogExampleState();
+}
+
+class _ModalDialogExampleState extends State<ModalDialogExample> {
+  bool enableOvershootEffect = false;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       bottomNavigationBar: const ExampleBottomAppBar(),
       body: Center(
-        child: ElevatedButton(
-          onPressed: () => showModalDialog(context),
-          child: const Text("Press Me"),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: () => _MyDialog.show(
+                context: context,
+                enableOvershootEffect: enableOvershootEffect,
+              ),
+              child: const Text("Click on me!"),
+            ),
+            SizedBox(height: 82),
+            Text(
+              'Overshoot Effect is ${enableOvershootEffect ? 'enabled' : 'disabled'}',
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            Switch(
+              value: enableOvershootEffect,
+              onChanged: (enabled) => setState(() {
+                enableOvershootEffect = enabled;
+              }),
+            ),
+          ],
         ),
       ),
     );
   }
 }
 
-void showModalDialog(BuildContext context) {
-  showModalExprollable(
-    context,
-    useSafeArea: false,
-    builder: (context) {
-      return ExprollablePageView(
-        itemCount: 5,
-        itemBuilder: (context, page) {
-          return ExampleListView(
-            controller: PageContentScrollController.of(context),
-            page: page,
-          );
-        },
+class _MyDialog extends StatefulWidget {
+  const _MyDialog(this.enableOvershootEffect);
+
+  final bool enableOvershootEffect;
+
+  @override
+  State<_MyDialog> createState() => __MyDialogState();
+
+  static void show({
+    required BuildContext context,
+    required bool enableOvershootEffect,
+  }) =>
+      showModalExprollable(
+        context,
+        useSafeArea: false,
+        builder: (context) => _MyDialog(enableOvershootEffect),
       );
-    },
-  );
+}
+
+class __MyDialogState extends State<_MyDialog> {
+  late final ExprollablePageController controller;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = ExprollablePageController(
+      viewportConfiguration: ViewportConfiguration(
+        extendPage: true,
+        overshootEffect: widget.enableOvershootEffect,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    controller.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ExprollablePageView(
+      controller: controller,
+      itemCount: 5,
+      itemBuilder: (context, page) {
+        return ExampleListView(
+          controller: PageContentScrollController.of(context),
+          page: page,
+        );
+      },
+    );
+  }
 }

--- a/example/lib/src/overshoot_effect_example.dart
+++ b/example/lib/src/overshoot_effect_example.dart
@@ -16,9 +16,6 @@ class _OvershootEffectExampleState extends State<OvershootEffectExample> {
   void initState() {
     super.initState();
     controller = ExprollablePageController(
-      // Make sure that your Scaffold has a bottom navigation bar,
-      // and Scaffold.extendBody is set true. You should avoid using
-      // SafeArea for the top of the screen for better visual effect.
       viewportConfiguration: ViewportConfiguration(
         overshootEffect: true,
       ),
@@ -34,7 +31,6 @@ class _OvershootEffectExampleState extends State<OvershootEffectExample> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      extendBody: true,
       bottomNavigationBar: const ExampleBottomAppBar(),
       body: ExprollablePageView(
         controller: controller,

--- a/package/README.md
+++ b/package/README.md
@@ -12,9 +12,13 @@ Here is an example of what you can do with this widget:
 
 ## Announcement
 
+### XX-XX-2023
+
+The first stable version has been released. See [the migration guide](#100-rcx-to-1x) for more details.
+
 ### 17-05-2023
 
-Version 1.0.0-rc.1 has been released 🎉. This version includes several breaking changes, so if you are already using ^1.0.0-beta, you may need to migrate according to [the migration guide](#100-beta-to-100-rc1).
+Version 1.0.0-rc.1 has been released 🎉. This version includes several breaking changes, so if you are already using ^1.0.0-beta, you may need to migrate according to [the migration guide](#100-betax-to-100-rcx).
 
 
 
@@ -22,6 +26,7 @@ Version 1.0.0-rc.1 has been released 🎉. This version includes several breakin
 
 - [exprollable\_page\_view 🐦](#exprollable_page_view-)
   - [Announcement](#announcement)
+    - [XX-XX-2023](#xx-xx-2023)
     - [17-05-2023](#17-05-2023)
   - [Index](#index)
   - [Background](#background)
@@ -47,7 +52,8 @@ Version 1.0.0-rc.1 has been released 🎉. This version includes several breakin
     - [prevent my app bar going off the screen when overshoote ffect is true?](#prevent-my-app-bar-going-off-the-screen-when-overshoote-ffect-is-true)
     - [animate the viewport state?](#animate-the-viewport-state)
   - [Migration guide](#migration-guide)
-    - [^1.0.0-beta to ^1.0.0-rc.1](#100-beta-to-100-rc1)
+    - [1.0.0-rc.x to 1.x](#100-rcx-to-1x)
+    - [1.0.0-beta.x to 1.0.0-rc.x](#100-betax-to-100-rcx)
       - [PageViewportMetrics update](#pageviewportmetrics-update)
       - [ViewportController update](#viewportcontroller-update)
       - [ViewportOffset update](#viewportoffset-update)
@@ -56,13 +62,14 @@ Version 1.0.0-rc.1 has been released 🎉. This version includes several breakin
   - [Questions](#questions)
   - [Contributing](#contributing)
 
-
 ## Background
 
 Books, an e-book reading application from Apple, has a unique user interface; tapping a book cover image displays its details page as a modal view, and the user can swpie the pages back and forth to explore the details of different books, and if the user scrolls vertically up the page, the width of the page gradually expands (or shrinks). The beauty of this UI is that:
 
 - the user can see at a glance that they can move between content by swiping
+
 - it does not reduce the horizontal space for the layout because it can go full-screen
+
 - the page switching by swiping is disabled in fullscreen mode, which allows both horizontal swipe actions like flutter_slidable and page switching in the page view.
 
 <img width="260" src="https://github.com/fujidaiti/exprollable_page_view/assets/68946713/daa8a72f-6904-4b45-ac2b-913e8fb9974a">
@@ -201,31 +208,7 @@ User defined insets can be created using `ViewportInset.fixed` and `ViewportInse
 
  <img width="260" src="https://user-images.githubusercontent.com/68946713/231827364-40843efc-5a91-49ff-ab74-c9af1e4b0c62.gif"><img width="260" src="https://user-images.githubusercontent.com/68946713/231827343-155a750d-b21f-4a96-b81a-74c8873c46cb.gif"><img width="260" src="https://github.com/fujidaiti/exprollable_page_view/assets/68946713/ef450917-4339-4ae1-b149-bca1e4699c2a">
 
-Overshoot effect will works correctly only if:
 
-- `MediaQuery.padding.bottom` > 0
-- Ther lower segment of `ExprollablePageView` is behind a widget such as `NavigationBar`, `BottomAppBar`
-
-Perhaps the most common use is to wrap an `ExprollablePageView` with a `Scaffold`. In that case, do not forget to enable `Scaffold.extentBody` and then everything should be fine.
-
-```dart
-  controller = ExprollablePageController(
-    viewportConfiguration: ViewportConfiguration(
-     overshootEffect: true, // Enable the overshoot effect
-    ),
-  );
-  
-  Widget build(BuildContext context) {
-    return Scaffold(
-      extendBody: true, // Do not forget this line
-      bottomNavigationBar: BottomNavigationBar(...),
-      body: ExprollablePageView(
-        controller: controller,
-        itemBuilder: (context, page) { ... },
-      ),
-    );
-  }
-```
 
 ### ViewportConfiguration
 
@@ -273,7 +256,9 @@ showModalExprollable(
   );
 ```
 
-<img width="260" src="https://user-images.githubusercontent.com/68946713/231827874-71a0ea47-6576-4fcc-ae37-d1bc38825234.gif">
+See [this example](https://github.com/fujidaiti/exprollable_page_view/blob/master/example/lib/src/modal_dialog_example.dart) for more detailed usage.
+
+<img width="260" src="https://github.com/fujidaiti/exprollable_page_view/assets/68946713/ec375a0d-0844-481c-a8ae-47cb5bb24b19">
 
 
 ### Slidable list items
@@ -424,7 +409,38 @@ A more concrete example can be seen in [animation_example.dart](https://github.c
 
 ## Migration guide
 
-### ^1.0.0-beta to ^1.0.0-rc.1
+### 1.0.0-rc.x to 1.x
+
+Prior to version 1.0.0, the overshoot effect only worked if the following conditions were satisfied:
+
+- `MediaQuery.padding.bottom` > 0
+- The bottom part of the `ExprollablePageView` is behind a widget like `NavigationBar` or `BottomAppBar`.
+
+Starting with version 1.0.0, the above restriction has been removed and the overshoot effect can be enabled with or without a bottom app bar. Also, `Scaffold.extendBody` is now optional.
+
+```dart
+  controller = ExprollablePageController(
+    viewportConfiguration: ViewportConfiguration(
+     overshootEffect: true,
+    ),
+  );
+  
+  Widget build(BuildContext context) {
+    return Scaffold(
+      // These two lines are no longer required in version 1.0.0 or later
+      // extendBody: true,
+      // bottomNavigationBar: BottomNavigationBar(...),
+      body: ExprollablePageView(
+        controller: controller,
+        itemBuilder: (context, page) { ... },
+      ),
+    );
+  }
+```
+
+
+
+### 1.0.0-beta.x to 1.0.0-rc.x
 
 With the release of version 1.0.0-rc.1, there are several breaking changes.
 

--- a/package/lib/src/core/controller.dart
+++ b/package/lib/src/core/controller.dart
@@ -237,6 +237,49 @@ class ViewportDimensions {
   int get hashCode => Object.hash(runtimeType, width, height, padding);
 }
 
+/// A description of the page viewport mesurements.
+@immutable
+class PageViewportDimensions {
+  const PageViewportDimensions({
+    required this.minWidth,
+    required this.minHeight,
+    required this.maxWidth,
+    required this.maxHeight,
+    required this.width,
+    required this.height,
+  });
+
+  final double minWidth;
+  final double maxWidth;
+  final double minHeight;
+  final double maxHeight;
+  final double width;
+  final double height;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (runtimeType == other.runtimeType &&
+          other is PageViewportDimensions &&
+          minWidth == other.minWidth &&
+          maxWidth == other.maxWidth &&
+          minHeight == other.minHeight &&
+          maxHeight == other.maxHeight &&
+          width == other.width &&
+          height == other.height);
+
+  @override
+  int get hashCode => Object.hash(
+        runtimeType,
+        minWidth,
+        maxWidth,
+        minHeight,
+        maxHeight,
+        width,
+        height,
+      );
+}
+
 /// A description of the viewport state.
 ///
 /// {@template exprollable_page_view.controller.ViewportMetrics}

--- a/package/lib/src/core/controller.dart
+++ b/package/lib/src/core/controller.dart
@@ -988,9 +988,11 @@ class OvershootViewportInset extends ViewportInset {
   /// Create the overshot viewport inset.
   const OvershootViewportInset();
 
+  static const _defaultPixels = -82.0;
+
   @override
   double toConcreteValue(ViewportMetrics metrics) =>
-      -1 * metrics.dimensions.padding.bottom;
+      min(-1 * metrics.dimensions.padding.bottom, _defaultPixels);
 }
 
 /// {@template exprollable_page_view.controller.DefaultExpandedViewportInset}

--- a/package/lib/src/core/controller.dart
+++ b/package/lib/src/core/controller.dart
@@ -553,32 +553,6 @@ class ViewportConfiguration {
   ///
   /// ![overshoot-disabled](https://user-images.githubusercontent.com/68946713/231827343-155a750d-b21f-4a96-b81a-74c8873c46cb.gif) ![overshoot-enabled](https://user-images.githubusercontent.com/68946713/231827364-40843efc-5a91-49ff-ab74-c9af1e4b0c62.gif)
   ///
-  /// Overshoot effect will works correctly only if:
-  ///
-  /// - [MediaQueryData.padding.data] > 0
-  /// - Ther lower segment of [ExprollablePageView] is behind a widget such as [NavigationBar], [BottomAppBar]
-  ///
-  /// Perhaps the most common use is to wrap an [ExprollablePageView] with a [Scaffold].
-  /// In that case, do not forget to enable [Scaffold.extentBody] and then everything should be fine.
-  ///
-  /// ```dart
-  /// controller = ExprollablePageController(
-  ///   viewportConfiguration: ViewportConfiguration(
-  ///    overshootEffect: true,
-  ///   ),
-  /// );
-  ///
-  /// Widget build(BuildContext context) {
-  ///   return Scaffold(
-  ///     extendBody: true,
-  ///     bottomNavigationBar: BottomNavigationBar(...),
-  ///     body: ExprollablePageView(
-  ///       controller: controller,
-  ///       itemBuilder: (context, page) { ... },
-  ///     ),
-  ///   );
-  /// }
-  /// ```
   factory ViewportConfiguration({
     bool overshootEffect = false,
     bool extendPage = false,

--- a/package/lib/src/core/view.dart
+++ b/package/lib/src/core/view.dart
@@ -26,14 +26,14 @@ class ExprollablePageView extends StatefulWidget {
   });
 
   /// A builder that creates a scrollable page for a given index.
-  /// 
+  ///
   /// Note that **[ExprollablePageView] will not works as expected
   /// if a [ScrollController] obtained by [PageContentScrollController.of]
   /// is not attached to the scrollable widget that is returned**.
   final IndexedWidgetBuilder itemBuilder;
 
   /// The number of pages.
-  /// 
+  ///
   /// Providing null makes the [ExprollablePageView] to scroll infinitely.
   final int? itemCount;
 
@@ -41,53 +41,53 @@ class ExprollablePageView extends StatefulWidget {
   final ExprollablePageController? controller;
 
   /// Whether the page view scrolls in the reading direction.
-  /// 
+  ///
   /// See [PageView.reverse] for more details.
   final bool reverse;
 
   /// How the page view should respond to user input.
-  /// 
+  ///
   /// See [PageView.physics] for more details.
   final ScrollPhysics? physics;
 
   /// Determines the way that drag start behavior is handled.
-  /// 
+  ///
   /// See [PageView.dragStartBehavior] for more details.
   final DragStartBehavior dragStartBehavior;
 
   /// Controls whether the widget's pages will respond to [RenderObject.showOnScreen],
   /// which will allow for implicit accessibility scrolling.
-  /// 
+  ///
   /// See [PageView.allowImplicitScrolling] for more detials.
   final bool allowImplicitScrolling;
 
   /// Restoration ID to save and restore the scroll offset of the scrollable.
-  /// 
+  ///
   /// See [PageView.restorationId] for more details.
   final String? restorationId;
 
   /// The content will be clipped (or not) according to this option.
-  /// 
+  ///
   /// See [PageView.clipBehavior] for more details.
   final Clip clipBehavior;
 
   /// A [ScrollBehavior] that will be applied to this widget individually.
-  /// 
+  ///
   /// See [PageView.scrollBehavior] for more detials.
   final ScrollBehavior? scrollBehavior;
 
   /// Whether to add padding to both ends of the list.
-  /// 
+  ///
   /// See [PageView.padEnds] for more details.
   final bool padEnds;
 
   /// Called whnever the viewport fraction or inset changes.
-  /// 
+  ///
   /// Providing this callback is equivalent to subscribing to [ExprollablePageController.viewport].
   final void Function(ViewportMetrics metrics)? onViewportChanged;
 
   /// Called whenever the focused page changes.
-  /// 
+  ///
   /// Providing this callback is equivalent to subscribing to [ExprollablePageController.currentPage].
   final void Function(int page)? onPageChanged;
 
@@ -165,6 +165,14 @@ class _ExprollablePageViewState extends State<ExprollablePageView> {
             ),
           );
 
+          final pageDimensions = controller.viewport.pageDimensions;
+          final pageConstraints = BoxConstraints(
+            minWidth: pageDimensions.maxWidth,
+            maxWidth: pageDimensions.maxWidth,
+            minHeight: pageDimensions.maxHeight,
+            maxHeight: pageDimensions.maxHeight,
+          );
+
           return ValueListenableBuilder(
             valueListenable: allowPaging,
             builder: (context, allowPaging, _) {
@@ -176,7 +184,8 @@ class _ExprollablePageViewState extends State<ExprollablePageView> {
                     child: child,
                   );
                 },
-                child: AlwaysFillViewportPageView.builder(
+                child: OverflowPageView.builder(
+                  childConstraints: pageConstraints,
                   reverse: widget.reverse,
                   dragStartBehavior: widget.dragStartBehavior,
                   allowImplicitScrolling: widget.allowImplicitScrolling,

--- a/package/lib/src/internal/paging.dart
+++ b/package/lib/src/internal/paging.dart
@@ -49,7 +49,7 @@ class _RenderSliverFillViewport extends RenderSliverFillViewport {
   });
 
   // This is the only change made in this class.
-  final BoxConstraints childConstraints;
+  BoxConstraints childConstraints;
 
   int _calculateLeadingGarbage(int firstIndex) {
     RenderBox? walker = firstChild;
@@ -262,6 +262,9 @@ class _SliverFillViewportRenderObjectWidget
   void updateRenderObject(
       BuildContext context, RenderSliverFillViewport renderObject) {
     renderObject.viewportFraction = viewportFraction;
+    assert(renderObject is _RenderSliverFillViewport);
+    (renderObject as _RenderSliverFillViewport).childConstraints =
+        childConstraints;
   }
 }
 

--- a/package/lib/src/internal/paging.dart
+++ b/package/lib/src/internal/paging.dart
@@ -45,7 +45,11 @@ class _RenderSliverFillViewport extends RenderSliverFillViewport {
   _RenderSliverFillViewport({
     required super.childManager,
     super.viewportFraction,
+    required this.childConstraints,
   });
+
+  // This is the only change made in this class.
+  final BoxConstraints childConstraints;
 
   int _calculateLeadingGarbage(int firstIndex) {
     RenderBox? walker = firstChild;
@@ -82,12 +86,12 @@ class _RenderSliverFillViewport extends RenderSliverFillViewport {
     assert(remainingExtent >= 0.0);
     final double targetEndScrollOffset = scrollOffset + remainingExtent;
 
-    // This is the only part that differs from the original implementation.
-    // Ignore `itemExtent` and force each child to always fill the viewport.
-    final BoxConstraints childConstraints = constraints.asBoxConstraints(
-      minExtent: constraints.viewportMainAxisExtent,
-      maxExtent: constraints.viewportMainAxisExtent,
-    );
+    // The original implementation.
+    //
+    // final BoxConstraints childConstraints = constraints.asBoxConstraints(
+    //   minExtent: itemExtent,
+    //   maxExtent: itemExtent,
+    // );
 
     final int firstIndex =
         getMinChildIndexForScrollOffset(scrollOffset, itemExtent);
@@ -236,17 +240,22 @@ class _SliverFillViewportRenderObjectWidget
     extends SliverMultiBoxAdaptorWidget {
   const _SliverFillViewportRenderObjectWidget({
     required super.delegate,
+    required this.childConstraints,
     this.viewportFraction = 1.0,
   }) : assert(viewportFraction > 0.0);
 
   final double viewportFraction;
+  final BoxConstraints childConstraints;
 
   @override
   RenderSliverFillViewport createRenderObject(BuildContext context) {
     final SliverMultiBoxAdaptorElement element =
         context as SliverMultiBoxAdaptorElement;
     return _RenderSliverFillViewport(
-        childManager: element, viewportFraction: viewportFraction);
+      childManager: element,
+      viewportFraction: viewportFraction,
+      childConstraints: childConstraints,
+    );
   }
 
   @override
@@ -261,7 +270,10 @@ class _SliverFillViewport extends SliverFillViewport {
     required super.delegate,
     super.padEnds,
     super.viewportFraction,
+    required this.childConstraints,
   });
+
+  final BoxConstraints childConstraints;
 
   @override
   Widget build(BuildContext context) {
@@ -271,6 +283,7 @@ class _SliverFillViewport extends SliverFillViewport {
       sliver: _SliverFillViewportRenderObjectWidget(
         delegate: delegate,
         viewportFraction: viewportFraction,
+        childConstraints: childConstraints,
       ),
     );
   }
@@ -353,10 +366,10 @@ class _RenderSliverFractionalPadding extends RenderSliverEdgeInsetsPadding {
   }
 }
 
-/// A page view that forces the pages to occupy the viewport
-/// regardless of [PageController.viewportFraction].
-class AlwaysFillViewportPageView extends PageView {
-  AlwaysFillViewportPageView.builder({
+/// A page view that imposes different constraints on each page
+/// than it gets from its parent, possibly allowing the pages to overflow the parent.
+class OverflowPageView extends PageView {
+  OverflowPageView.builder({
     super.key,
     super.scrollDirection,
     super.reverse,
@@ -373,7 +386,10 @@ class AlwaysFillViewportPageView extends PageView {
     super.clipBehavior,
     super.scrollBehavior,
     super.padEnds,
+    required this.childConstraints,
   }) : super.builder();
+
+  final BoxConstraints childConstraints;
 
   @override
   State<PageView> createState() => _PageViewState();
@@ -383,7 +399,7 @@ const PageScrollPhysics _kPagePhysics = PageScrollPhysics();
 
 /// This class was copied and modified from:
 /// - https://github.com/flutter/flutter/tree/master/packages/flutter/lib/src/widgets/page_view.dart
-class _PageViewState extends State<PageView> {
+class _PageViewState extends State<OverflowPageView> {
   int _lastReportedPage = 0;
 
   @override
@@ -453,6 +469,7 @@ class _PageViewState extends State<PageView> {
                 viewportFraction: widget.controller.viewportFraction,
                 delegate: widget.childrenDelegate,
                 padEnds: widget.padEnds,
+                childConstraints: widget.childConstraints,
               ),
             ],
           );

--- a/package/res/README.jp.md
+++ b/package/res/README.jp.md
@@ -10,15 +10,19 @@
 
 ## アナウンス
 
+### XX-XX-2023
+
+安定版のバージョン1.0.0がリリースされました。詳しくは [マイグレーションガイド](#100-rcx-から-1x)をご覧ください。
+
 ### 2023/05/17
 
-バージョン1.0.0-rc.1がリリースされました 🎉！このバージョンはいくつかの破壊的な変更を含んでいます。もしベータ版（1.0.0-beta.xx）をすでに使用中の場合、コードの修正が必要になるかもしれません。詳しくは [マイグレーションガイド](#100-beta-to-100-rc1)をご覧ください。
-
+バージョン1.0.0-rc.1がリリースされました 🎉！このバージョンはいくつかの破壊的な変更を含んでいます。もしベータ版（1.0.0-beta.xx）をすでに使用中の場合、コードの修正が必要になるかもしれません。詳しくは [マイグレーションガイド](100-beta-から-100-rc1)をご覧ください。
 
 ## 目次
 
 - [exprollable\_page\_view 🐦](#exprollable_page_view-)
   - [アナウンス](#アナウンス)
+    - [XX-XX-2023](#xx-xx-2023)
     - [2023/05/17](#20230517)
   - [目次](#目次)
   - [試してみる](#試してみる)
@@ -42,12 +46,14 @@
     - [overshoot effectが有効なときapp barが画面の外に飛び出してしまうのを防ぐ](#overshoot-effectが有効なときapp-barが画面の外に飛び出してしまうのを防ぐ)
     - [viewportの状態をアニメーションで動かす](#viewportの状態をアニメーションで動かす)
   - [マイグレーションガイド](#マイグレーションガイド)
+    - [1.0.0-rc.x から 1.x](#100-rcx-から-1x)
     - [^1.0.0-beta から ^1.0.0-rc.1](#100-beta-から-100-rc1)
       - [PageViewportMetricsの変更](#pageviewportmetricsの変更)
       - [ViewportControllerの変更](#viewportcontrollerの変更)
       - [ViewportOffsetの変更](#viewportoffsetの変更)
       - [ExprollablePageControllerの変更](#exprollablepagecontrollerの変更)
       - [その他シンボル名の変更](#その他シンボル名の変更)
+
 
 ## 試してみる
 
@@ -177,32 +183,6 @@ overshoot effectはページが拡大される際の視覚効果です。これ�
 
  <img width="260" src="https://user-images.githubusercontent.com/68946713/231827364-40843efc-5a91-49ff-ab74-c9af1e4b0c62.gif"><img width="260" src="https://user-images.githubusercontent.com/68946713/231827343-155a750d-b21f-4a96-b81a-74c8873c46cb.gif"><img width="260" src="https://github.com/fujidaiti/exprollable_page_view/assets/68946713/ef450917-4339-4ae1-b149-bca1e4699c2a">
 
-overshoot effectが正しく動作するには以下の条件を満たす必要があります。
-
-- `MediaQuery.padding.bottom` > 0
-- `NavigationBar`や`BottomAppBar`のようなwidgetが`ExprollablePageView`の下部を覆い隠している
-
-おそらく最もよくある使用方法は`Scaffold`の中に`ExprollablePageView`を設置することでしょう。その場合`Scaffold.bottomNavigationBar`を指定し、`Scaffold.extentBody`を有効にしてください。これにより上記の条件が満たされます。
-
-```dart
-  controller = ExprollablePageController(
-    viewportConfiguration: ViewportConfiguration(
-     overshootEffect: true, // overshoot effectを有効にする
-    ),
-  );
-  
-  Widget build(BuildContext context) {
-    return Scaffold(
-      extendBody: true, // これを忘れずに
-      bottomNavigationBar: BottomNavigationBar(...),
-      body: ExprollablePageView(
-        controller: controller,
-        itemBuilder: (context, page) { ... },
-      ),
-    );
-  }
-```
-
 ### ViewportConfiguration
 
 `ViewportConfiguration` はviewportの動作をカスタマイズするための柔軟な方法を提供します。ほとんどのケースでは`ViewportConfiguration`の無名コンストラクタで十分だと思いますが、より細かい制御が必要な場合は、`ViewportConfiguration.raw`を使用してください。viewport fractionとinsetの範囲、またページが完全に拡大（縮小）する位置を指定することができます。以下のコードはページを4つの状態にスナップさせる`ExprollablePageController`の例です。
@@ -249,8 +229,9 @@ showModalExprollable(
   );
 ```
 
-<img width="260" src="https://user-images.githubusercontent.com/68946713/231827874-71a0ea47-6576-4fcc-ae37-d1bc38825234.gif">
+より詳しい例は [modal_dialog_example.dart](https://github.com/fujidaiti/exprollable_page_view/blob/master/example/lib/src/modal_dialog_example.dart) をご覧ください。
 
+<img width="260" src="https://github.com/fujidaiti/exprollable_page_view/assets/68946713/ec375a0d-0844-481c-a8ae-47cb5bb24b19">
 
 ### スライドアクションを持つリストアイテム
 
@@ -397,6 +378,36 @@ controller.animateViewportInsetTo(
 <img width="260" src="https://github.com/fujidaiti/fms/assets/68946713/63b2a875-3b54-4031-9817-a808bce2b3f8">
 
 ## マイグレーションガイド
+
+
+### 1.0.0-rc.x から 1.x
+
+バージョン1.0.0以前では、overshoot effectは以下の条件を満たした場合のみ正しく機能しました。
+
+- `MediaQuery.padding.bottom` > 0
+- `NavigationBar`や`BottomAppBar`のようなwidgetが`ExprollablePageView`の下部を覆い隠している
+
+バージョン1.0.0からは上記の制限がなくなり、`Scaffold.bottomNavigationBar`や`Scaffold.extendBody`の有無に関わらずovershoot effectを有効にすることができるようになりました。
+
+```dart
+  controller = ExprollablePageController(
+    viewportConfiguration: ViewportConfiguration(
+     overshootEffect: true,
+    ),
+  );
+  
+  Widget build(BuildContext context) {
+    return Scaffold(
+      // 以下の２行はバージョン1.0.0以降では不要になりました
+      // extendBody: true,
+      // bottomNavigationBar: BottomNavigationBar(...),
+      body: ExprollablePageView(
+        controller: controller,
+        itemBuilder: (context, page) { ... },
+      ),
+    );
+  }
+```
 
 ### ^1.0.0-beta から ^1.0.0-rc.1
 


### PR DESCRIPTION
This PR removes the following limitations on the overshoot effect:

- `MediaQuery.padding.bottom` must be greater than 0,
- The bottom part of the `ExprollablePageView` is behind a widget like `NavigationBar` or `BottomAppBar`.

The documents have been updated as well.