### PR TITLE
Add upper SDK constraint to 3.20.0

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 1.0.1 Feb 24, 2024
+
+Temporarily add the upper constraint of the Flutter SDK version to 3.20.0, since the current SDK used to analyze packages on pub.dev is 3.20.0-1.1.pre, which has a breaking change in the `PageView' class and is not compatible with the current version of this package, resulting in static analysis errors on pub.dev.
+
 ## 1.0.0 Feb 24, 2024
 
-- Dart3 is now required.
+Dart3 is now required.
 
 ## 1.0.0-rc.2 Jun 17, 2023
 

--- a/package/lib/src/addon/modal.dart
+++ b/package/lib/src/addon/modal.dart
@@ -235,9 +235,7 @@ class ModalExprollableScrollPhysics extends ScrollPhysics {
   /// This physics will delegate its logic to a [BouncingScrollPhysics]
   /// while the user is overscrolling, so that the *drag down to dismiss* action is available
   /// on every platform. Otherwise, it delegates to the given [parent].
-  const ModalExprollableScrollPhysics({
-    ScrollPhysics? parent,
-  }) : super(parent: parent);
+  const ModalExprollableScrollPhysics({super.parent});
 
   @override
   ModalExprollableScrollPhysics applyTo(ScrollPhysics? ancestor) {

--- a/package/lib/src/internal/paging.dart
+++ b/package/lib/src/internal/paging.dart
@@ -1,11 +1,11 @@
-/// Copied and modified from:
-/// - https://github.com/flutter/flutter/tree/master/packages/flutter/lib/src/widgets/page_view.dart
-/// - https://github.com/flutter/flutter/tree/master/packages/flutter/lib/src/rendering/sliver_fill.dart
-///
-/// Changes done:
-/// - Replace [SliverFillViewport] with [_SliverFillViewport] in [_PageViewState.build]
-/// - In [_RenderSliverFillViewport.performLayout], force the children to always occupy the parent viewport,
-///   regardless of [_RenderSliverFillViewport.itemExtent].
+// Copied and modified from:
+// - https://github.com/flutter/flutter/tree/master/packages/flutter/lib/src/widgets/page_view.dart
+// - https://github.com/flutter/flutter/tree/master/packages/flutter/lib/src/rendering/sliver_fill.dart
+//
+// Changes done:
+// - Replace [SliverFillViewport] with [_SliverFillViewport] in [_PageViewState.build]
+// - In [_RenderSliverFillViewport.performLayout], force the children to always occupy the parent viewport,
+//   regardless of [_RenderSliverFillViewport.itemExtent].
 
 // Copyright 2014 The Flutter Authors. All rights reserved.
 //

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/fujidaiti/exprollable_page_view
 
 environment:
   sdk: ">=3.0.6 <4.0.0"
-  flutter: ">=3.10.6"
+  flutter: ">=3.10.6 < 3.20.0"
 
 dependencies:
   flutter:

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: exprollable_page_view
 description: Yet another PageView widget that expands its page while scrolling it. Exprollable is a coined word combining the words expandable and scrollable.
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/fujidaiti/exprollable_page_view
 
 environment:


### PR DESCRIPTION
Temporarily set the upper constraint of the Flutter SDK version to `3.20.0`. This is necessary because the current SDK used to analyze packages on pub.dev is `3.20.0-1.1.pre`, which has a breaking change in the `PageView` class that is not compatible with the current version of this package. As a result, static analysis errors occur on pub.dev.