### PR TITLE
Migrate to flutter 3.20.0.pre

### DIFF
--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1 Feb 25, 2024
+
+- Small refactoring (no functional changes).
+
 ## 1.0.0 Feb 24, 2024
 
 - Dart3 is now required.

--- a/package/lib/src/addon/modal.dart
+++ b/package/lib/src/addon/modal.dart
@@ -235,9 +235,7 @@ class ModalExprollableScrollPhysics extends ScrollPhysics {
   /// This physics will delegate its logic to a [BouncingScrollPhysics]
   /// while the user is overscrolling, so that the *drag down to dismiss* action is available
   /// on every platform. Otherwise, it delegates to the given [parent].
-  const ModalExprollableScrollPhysics({
-    ScrollPhysics? parent,
-  }) : super(parent: parent);
+  const ModalExprollableScrollPhysics({super.parent});
 
   @override
   ModalExprollableScrollPhysics applyTo(ScrollPhysics? ancestor) {

--- a/package/lib/src/internal/paging.dart
+++ b/package/lib/src/internal/paging.dart
@@ -376,7 +376,7 @@ class OverflowPageView extends PageView {
     super.key,
     super.scrollDirection,
     super.reverse,
-    super.controller,
+    required PageController controller,
     super.physics,
     super.pageSnapping,
     super.onPageChanged,
@@ -390,7 +390,7 @@ class OverflowPageView extends PageView {
     super.scrollBehavior,
     super.padEnds,
     required this.childConstraints,
-  }) : super.builder();
+  }) : super.builder(controller: controller);
 
   final BoxConstraints childConstraints;
 
@@ -408,7 +408,9 @@ class _PageViewState extends State<OverflowPageView> {
   @override
   void initState() {
     super.initState();
-    _lastReportedPage = widget.controller.initialPage;
+    // FIXME: Workaround to pass the static analysis on pub.dev
+    // ignore: unnecessary_non_null_assertion
+    _lastReportedPage = widget.controller!.initialPage;
   }
 
   AxisDirection _getDirection(BuildContext context) {
@@ -469,7 +471,9 @@ class _PageViewState extends State<OverflowPageView> {
             clipBehavior: widget.clipBehavior,
             slivers: <Widget>[
               _SliverFillViewport(
-                viewportFraction: widget.controller.viewportFraction,
+                // FIXME: Workaround to pass the static analysis on pub.dev
+                // ignore: unnecessary_non_null_assertion
+                viewportFraction: widget.controller!.viewportFraction,
                 delegate: widget.childrenDelegate,
                 padEnds: widget.padEnds,
                 childConstraints: widget.childConstraints,

--- a/package/lib/src/internal/paging.dart
+++ b/package/lib/src/internal/paging.dart
@@ -1,11 +1,11 @@
-/// Copied and modified from:
-/// - https://github.com/flutter/flutter/tree/master/packages/flutter/lib/src/widgets/page_view.dart
-/// - https://github.com/flutter/flutter/tree/master/packages/flutter/lib/src/rendering/sliver_fill.dart
-///
-/// Changes done:
-/// - Replace [SliverFillViewport] with [_SliverFillViewport] in [_PageViewState.build]
-/// - In [_RenderSliverFillViewport.performLayout], force the children to always occupy the parent viewport,
-///   regardless of [_RenderSliverFillViewport.itemExtent].
+// Copied and modified from:
+// - https://github.com/flutter/flutter/tree/master/packages/flutter/lib/src/widgets/page_view.dart
+// - https://github.com/flutter/flutter/tree/master/packages/flutter/lib/src/rendering/sliver_fill.dart
+//
+// Changes done:
+// - Replace [SliverFillViewport] with [_SliverFillViewport] in [_PageViewState.build]
+// - In [_RenderSliverFillViewport.performLayout], force the children to always occupy the parent viewport,
+//   regardless of [_RenderSliverFillViewport.itemExtent].
 
 // Copyright 2014 The Flutter Authors. All rights reserved.
 //

--- a/package/pubspec.yaml
+++ b/package/pubspec.yaml
@@ -1,6 +1,6 @@
 name: exprollable_page_view
 description: Yet another PageView widget that expands its page while scrolling it. Exprollable is a coined word combining the words expandable and scrollable.
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/fujidaiti/exprollable_page_view
 
 environment:


### PR DESCRIPTION
Migrate to `3.20.0-1.1.pre`. This is necessary because the current SDK used to analyze packages on pub.dev is `3.20.0-1.1.pre`, which has a breaking change in the `PageView` class that is not compatible with the current version of this package (described below). As a result, static analysis errors occur on pub.dev.

## What changes will be made in 3.20?

`PageView.controller` will be nullable.

## How to migrate?

Make `OverflowPageView` always receive a non-nullable `PageController` in the constructor.